### PR TITLE
Add "WEIGHTS" option to ZINTERSTORE and ZUNIONSTORE

### DIFF
--- a/src/NServiceKit.Redis/Commands.cs
+++ b/src/NServiceKit.Redis/Commands.cs
@@ -168,6 +168,7 @@ namespace NServiceKit.Redis
         public readonly static byte[] Desc = "DESC".ToUtf8Bytes();
         public readonly static byte[] Alpha = "ALPHA".ToUtf8Bytes();
         public readonly static byte[] Store = "STORE".ToUtf8Bytes();
+        public readonly static byte[] Weights = "WEIGHTS".ToUtf8Bytes();
 
         public readonly static byte[] Eval = "EVAL".ToUtf8Bytes();
         public readonly static byte[] EvalSha = "EVALSHA".ToUtf8Bytes();

--- a/src/NServiceKit.Redis/RedisClient_SortedSet.cs
+++ b/src/NServiceKit.Redis/RedisClient_SortedSet.cs
@@ -429,5 +429,10 @@ namespace NServiceKit.Redis
 		{
 			return base.ZUnionStore(intoSetId, setIds);
 		}
-	}
+
+        public long StoreUnionFromSortedSetsWithWeights(string intoSetId, params KeyValuePair<string, double>[] setIdWithWeightPairs)
+        {
+            return base.ZUnionStoreWithWeights(intoSetId, setIdWithWeightPairs);
+        }
+    }
 }

--- a/src/NServiceKit.Redis/RedisClient_SortedSet.cs
+++ b/src/NServiceKit.Redis/RedisClient_SortedSet.cs
@@ -420,7 +420,12 @@ namespace NServiceKit.Redis
 			return base.ZInterStore(intoSetId, setIds);
 		}
 
-		public long StoreUnionFromSortedSets(string intoSetId, params string[] setIds)
+        public long StoreIntersectFromSortedSetsWithWeights(string intoSetId, params KeyValuePair<string, double>[] setIdWithWeightPairs)
+        {
+            return base.ZInterStoreWithWeights(intoSetId, setIdWithWeightPairs);
+        }
+
+        public long StoreUnionFromSortedSets(string intoSetId, params string[] setIds)
 		{
 			return base.ZUnionStore(intoSetId, setIds);
 		}

--- a/src/NServiceKit.Redis/RedisNativeClient.cs
+++ b/src/NServiceKit.Redis/RedisNativeClient.cs
@@ -1546,6 +1546,34 @@ namespace NServiceKit.Redis
             return SendExpectLong(cmdWithArgs);
         }
 
+        public long ZUnionStoreWithWeights(string intoSetId, params KeyValuePair<string, double>[] setIdWithWeightPairs)
+        {
+            var setIds = setIdWithWeightPairs.Select(x => x.Key).ToArray();
+            var weights = setIdWithWeightPairs.Select(x => x.Value).ToArray();
+            var cmdWithArgs = new List<byte[]>
+               {
+                   Commands.ZUnionStore, intoSetId.ToUtf8Bytes(), setIds.Length.ToUtf8Bytes()
+               };
+
+            // add the set ids
+            foreach (var setId in setIds)
+            {
+                cmdWithArgs.Add(setId.ToUtf8Bytes());
+            }
+
+            // add "WEIGHTS"
+            cmdWithArgs.Add(Commands.Weights);
+
+            // append the weights
+            foreach (var weight in weights)
+            {
+                cmdWithArgs.Add(weight.ToFastUtf8Bytes());
+            }
+
+            // send command
+            return SendExpectLong(cmdWithArgs.ToArray());
+        }
+
         public long ZInterStore(string intoSetId, params string[] setIds)
         {
             var setIdsList = new List<string>(setIds);

--- a/src/NServiceKit.Redis/RedisNativeClient.cs
+++ b/src/NServiceKit.Redis/RedisNativeClient.cs
@@ -1556,6 +1556,34 @@ namespace NServiceKit.Redis
             return SendExpectLong(cmdWithArgs);
         }
 
+        public long ZInterStoreWithWeights(string intoSetId, params KeyValuePair<string, double>[] setIdWithWeightPairs)
+        {
+            var setIds = setIdWithWeightPairs.Select(x => x.Key).ToArray();
+            var weights = setIdWithWeightPairs.Select(x => x.Value).ToArray();
+            var cmdWithArgs = new List<byte[]>
+               {
+                   Commands.ZInterStore, intoSetId.ToUtf8Bytes(), setIds.Length.ToUtf8Bytes()
+               };
+            
+            // add the set ids
+            foreach(var setId in setIds)
+            {
+                cmdWithArgs.Add(setId.ToUtf8Bytes());
+            }
+
+            // add "WEIGHTS"
+            cmdWithArgs.Add(Commands.Weights);
+
+            // append the weights
+            foreach (var weight in weights)
+            {
+                cmdWithArgs.Add(weight.ToFastUtf8Bytes());
+            }
+
+            // send command
+            return SendExpectLong(cmdWithArgs.ToArray());
+        }
+
         #endregion
 
 

--- a/tests/NServiceKit.Redis.Tests/RedisClientSortedSetTests.cs
+++ b/tests/NServiceKit.Redis.Tests/RedisClientSortedSetTests.cs
@@ -226,6 +226,28 @@ namespace NServiceKit.Redis.Tests
         }
 
         [Test]
+        public void Can_Store_UnionBetweenSetsWithWeights()
+        {
+            string set1Name = PrefixedKey("testintersectset1");
+            string set2Name = PrefixedKey("testintersectset2");
+            string storeSetName = PrefixedKey("testintersectsetstore");
+            Redis.AddItemToSortedSet(set1Name, "one", 10.0);
+            Redis.AddItemToSortedSet(set1Name, "three", 3.0);
+            Redis.AddItemToSortedSet(set1Name, "four", 2.0);
+            Redis.AddItemToSortedSet(set2Name, "four", 2.0);
+            Redis.AddItemToSortedSet(set2Name, "three", 1.0);
+            Redis.StoreIntersectFromSortedSetsWithWeights(storeSetName,
+                new KeyValuePair<string, double>(set1Name, 1.0),
+                new KeyValuePair<string, double>(set2Name, 3.0)
+            );
+            var intersectingMembers = Redis.GetAllWithScoresFromSortedSet(storeSetName);
+            Assert.AreEqual(3, intersectingMembers.Count);
+            Assert.AreEqual(6.0, intersectingMembers["three"]);
+            Assert.AreEqual(8.0, intersectingMembers["four"]);
+            Assert.AreEqual(10.0, intersectingMembers["one"]);
+        }
+
+        [Test]
 		public void Can_Store_UnionBetweenSets()
 		{
 			string set1Name = PrefixedKey("testunionset1");

--- a/tests/NServiceKit.Redis.Tests/RedisClientSortedSetTests.cs
+++ b/tests/NServiceKit.Redis.Tests/RedisClientSortedSetTests.cs
@@ -236,7 +236,7 @@ namespace NServiceKit.Redis.Tests
             Redis.AddItemToSortedSet(set1Name, "four", 2.0);
             Redis.AddItemToSortedSet(set2Name, "four", 2.0);
             Redis.AddItemToSortedSet(set2Name, "three", 1.0);
-            Redis.StoreIntersectFromSortedSetsWithWeights(storeSetName,
+            Redis.StoreUnionFromSortedSetsWithWeights(storeSetName,
                 new KeyValuePair<string, double>(set1Name, 1.0),
                 new KeyValuePair<string, double>(set2Name, 3.0)
             );

--- a/tests/NServiceKit.Redis.Tests/RedisClientSortedSetTests.cs
+++ b/tests/NServiceKit.Redis.Tests/RedisClientSortedSetTests.cs
@@ -205,7 +205,27 @@ namespace NServiceKit.Redis.Tests
 			Assert.That(intersectingMembers, Is.EquivalentTo(new List<string> { "four", "five" }));
 		}
 
-		[Test]
+        [Test]
+        public void Can_Store_IntersectBetweenSetsWithWeights()
+        {
+            string set1Name = PrefixedKey("testintersectset1");
+            string set2Name = PrefixedKey("testintersectset2");
+            string storeSetName = PrefixedKey("testintersectsetstore");
+            Redis.AddItemToSortedSet(set1Name, "three", 3.0);
+            Redis.AddItemToSortedSet(set1Name, "four", 2.0);
+            Redis.AddItemToSortedSet(set2Name, "four", 2.0);
+            Redis.AddItemToSortedSet(set2Name, "three", 1.0);
+            Redis.StoreIntersectFromSortedSetsWithWeights(storeSetName, 
+                new KeyValuePair<string, double>(set1Name, 1.0),
+                new KeyValuePair<string, double>(set2Name, 3.0)
+            );
+            var intersectingMembers = Redis.GetAllWithScoresFromSortedSet(storeSetName);
+            Assert.AreEqual(2, intersectingMembers.Count);
+            Assert.AreEqual(6.0, intersectingMembers["three"]);
+            Assert.AreEqual(8.0, intersectingMembers["four"]);
+        }
+
+        [Test]
 		public void Can_Store_UnionBetweenSets()
 		{
 			string set1Name = PrefixedKey("testunionset1");


### PR DESCRIPTION
This pull-request adds the ability to specify weights when performing a ZINTERSTORE and ZUNIONSTORE with 2 new commands: 

StoreUnionFromSortedSetsWithWeights
StoreIntersectFromSortedSetsWithWeights

Example:
ZINTERSTORE out 2 zset1 zset2 WEIGHTS 2 3

source: http://redis.io/commands/zinterstore

Goes together with: https://github.com/NServiceKit/NServiceKit/pull/43
